### PR TITLE
Fix_submodule_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ module "ad2" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | https://github.com/Coalfire-CF/terraform-aws-securitygroup | n/a |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | github.com/Coalfire-CF/terraform-aws-securitygroup | n/a |
 
 ## Resources
 
@@ -242,6 +242,7 @@ module "ad2" {
 |------|-------------|
 | <a name="output_iam_profile"></a> [iam\_profile](#output\_iam\_profile) | The name of the iam profile created in the module |
 | <a name="output_iam_role_arn"></a> [iam\_role\_arn](#output\_iam\_role\_arn) | The AWS IAM Role arn created |
+| <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | The AWS IAM Role arn created |
 | <a name="output_instance_id"></a> [instance\_id](#output\_instance\_id) | The AWS Instance id created |
 | <a name="output_primary_private_ip_addresses"></a> [primary\_private\_ip\_addresses](#output\_primary\_private\_ip\_addresses) | A list of the primary private IP addesses assigned to the ec2 instance |
 | <a name="output_sg_id"></a> [sg\_id](#output\_sg\_id) | The id of the security group created |

--- a/locals.tf
+++ b/locals.tf
@@ -10,7 +10,7 @@ locals {
 
 # For additional sg attachment
 locals {
-  additional_sg_to_primary_eni    = setproduct(var.additional_security_groups, aws_instance.this.*.primary_network_interface_id)
+  additional_sg_to_primary_eni    = setproduct(var.additional_security_groups, aws_instance.this[*].primary_network_interface_id)
   additional_sg_to_additional_eni = setproduct(var.additional_security_groups, var.additional_eni_ids)
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "instance_id" {
   description = "The AWS Instance id created"
-  value       = aws_instance.this.*.id
+  value       = aws_instance.this[*].id
 }
 
 output "sg_id" {
@@ -15,15 +15,19 @@ output "iam_profile" {
 
 output "primary_private_ip_addresses" {
   description = "A list of the primary private IP addesses assigned to the ec2 instance"
-  value       = aws_instance.this.*.private_ip
+  value       = aws_instance.this[*].private_ip
 }
 
 output "tags" {
   description = "List of tags of instances"
-  value       = aws_instance.this.*.tags
+  value       = aws_instance.this[*].tags
 }
 
 output "iam_role_arn" {
   description = "The AWS IAM Role arn created"
-  value       = aws_iam_role.this_role.*.arn
+  value       = aws_iam_role.this_role[*].arn
+}
+output "iam_role_name" {
+  description = "The AWS IAM Role arn created"
+  value       = aws_iam_role.this_role[*].name
 }

--- a/sg.tf
+++ b/sg.tf
@@ -1,5 +1,5 @@
 module "security_group" {
-  source = "https://github.com/Coalfire-CF/terraform-aws-securitygroup"
+  source = "github.com/Coalfire-CF/terraform-aws-securitygroup"
 
   name        = "${var.name}-sg"
   description = var.sg_description

--- a/target_group_attachment.tf
+++ b/target_group_attachment.tf
@@ -1,5 +1,5 @@
 resource "aws_lb_target_group_attachment" "target_group_attachment" {
   count            = local.full_size
-  target_group_arn = var.target_group_arns[floor(count.index / length(aws_instance.this.*.id))]
-  target_id        = aws_instance.this[count.index % length(aws_instance.this.*.id)].id
+  target_group_arn = var.target_group_arns[floor(count.index / length(aws_instance.this[*].id))]
+  target_id        = aws_instance.this[count.index % length(aws_instance.this[*].id)].id
 }


### PR DESCRIPTION
-Added instance role name as output as it is typically required to attach additional policies after instance creation.
-Changed Security Group module source to remove unnecessary "https://" which was preventing it from working.
-Changed references of "<resource>.*.<property>" to "<resource>[*].<property>", usually caught by tflint