### PR TITLE
Add_imds_var

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -12,7 +12,7 @@ resource "aws_instance" "this" {
   metadata_options {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
-    http_tokens                 = "required"
+    http_tokens                 = var.http_tokens
     instance_metadata_tags      = "enabled"
   }
 
@@ -59,6 +59,4 @@ resource "aws_instance" "this" {
   lifecycle {
     ignore_changes = [root_block_device, ebs_block_device, user_data, ami]
   }
-
-  depends_on = [var.module_depends_on]
 }

--- a/sg.tf
+++ b/sg.tf
@@ -1,5 +1,5 @@
 module "security_group" {
-  source = "https://github.com/Coalfire-CF/terraform-aws-securitygroup"
+  source = "github.com/Coalfire-CF/terraform-aws-securitygroup?ref=v1.0.0"
 
   name        = "${var.name}-sg"
   description = var.sg_description

--- a/variables.tf
+++ b/variables.tf
@@ -235,8 +235,12 @@ variable "assume_role_policy" {
 EOF
 }
 
-variable "module_depends_on" {
-  description = "A variable to simulate the depends on feature that resources have"
+variable "http_tokens" {
+  description = "Whether or not the metadata service requires session tokens, required=IMDSv2, optional=IMDSv1"
   type        = any
-  default     = null
+  default     = "required"
+  validation {
+    condition     = can(regex("^(required|optional)$", var.http_tokens))
+    error_message = "ERROR: Valid values are 'required' or 'optional'."
+  }
 }


### PR DESCRIPTION
Changes:
- Remove "depends_on", seems to be legacy code specifically for Active Directory deployment in Launchpad.  Not used anywhere in FastRMP, doesn't appear to be needed.  Causes unnecessary checkov failures if left in.
- Allow "http_tokens" to be set as a variable.  Would previously be set as a static value to enable IMDSv2, but there are rare use cases where an application requires IMDSv1 (such as the Palo Alto VM-Series appliance).  Default to IMDSv2 if not specified, but add variable to allow user override in these cases.