### PR TITLE
Fix_sg_attachment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,5 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @douglas-f and @i-ate-a-vm will be requested for
-# review when someone opens a pull request.
-*       @cstano @i-ate-a-vm
+# the repo.
+*       @az-kennedy @herman-wong-cf

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ module "ad2" {
 | <a name="output_iam_role_arn"></a> [iam\_role\_arn](#output\_iam\_role\_arn) | The AWS IAM Role arn created |
 | <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | The AWS IAM Role arn created |
 | <a name="output_instance_id"></a> [instance\_id](#output\_instance\_id) | The AWS Instance id created |
+| <a name="output_network_interface_id"></a> [network\_interface\_id](#output\_network\_interface\_id) | The network interface ID for the AWS instance |
 | <a name="output_primary_private_ip_addresses"></a> [primary\_private\_ip\_addresses](#output\_primary\_private\_ip\_addresses) | A list of the primary private IP addesses assigned to the ec2 instance |
 | <a name="output_sg_id"></a> [sg\_id](#output\_sg\_id) | The id of the security group created |
 | <a name="output_tags"></a> [tags](#output\_tags) | List of tags of instances |

--- a/README.md
+++ b/README.md
@@ -189,7 +189,6 @@ module "ad2" {
 | [aws_lb_target_group_attachment.target_group_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment) | resource |
 | [aws_network_interface_attachment.eni_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface_attachment) | resource |
 | [aws_network_interface_sg_attachment.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface_sg_attachment) | resource |
-| [aws_network_interface_sg_attachment.primary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface_sg_attachment) | resource |
 | [aws_volume_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/volume_attachment) | resource |
 | [aws_iam_policy.AmazonSSMManagedInstanceCore](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 

--- a/ec2.tf
+++ b/ec2.tf
@@ -21,7 +21,7 @@ resource "aws_instance" "this" {
   private_ip                  = var.private_ip
   associate_public_ip_address = var.associate_public_ip || var.associate_eip
   source_dest_check           = var.source_dest_check
-  vpc_security_group_ids      = length(var.additional_security_groups) > 0 ? [module.security_group.id] : []
+  vpc_security_group_ids      = length(var.additional_security_groups) > 0 ? [] : [module.security_group.id]
 
   ###  STORAGE  ###
   root_block_device {

--- a/ec2.tf
+++ b/ec2.tf
@@ -21,7 +21,7 @@ resource "aws_instance" "this" {
   private_ip                  = var.private_ip
   associate_public_ip_address = var.associate_public_ip || var.associate_eip
   source_dest_check           = var.source_dest_check
-  vpc_security_group_ids      = length(var.additional_security_groups) > 0 ? [] : [module.security_group.id]
+  vpc_security_group_ids      = length(var.additional_security_groups) > 0 ? concat([module.security_group.id], var.additional_security_groups) : [module.security_group.id]
 
   ###  STORAGE  ###
   root_block_device {

--- a/ec2.tf
+++ b/ec2.tf
@@ -21,7 +21,6 @@ resource "aws_instance" "this" {
   private_ip                  = var.private_ip
   associate_public_ip_address = var.associate_public_ip || var.associate_eip
   source_dest_check           = var.source_dest_check
-  #vpc_security_group_ids      = [module.security_group.id]
 
   ###  STORAGE  ###
   root_block_device {

--- a/ec2.tf
+++ b/ec2.tf
@@ -21,6 +21,7 @@ resource "aws_instance" "this" {
   private_ip                  = var.private_ip
   associate_public_ip_address = var.associate_public_ip || var.associate_eip
   source_dest_check           = var.source_dest_check
+  vpc_security_group_ids      = length(var.additional_security_groups) > 0 ? [module.security_group.id] : []
 
   ###  STORAGE  ###
   root_block_device {

--- a/ec2.tf
+++ b/ec2.tf
@@ -21,7 +21,7 @@ resource "aws_instance" "this" {
   private_ip                  = var.private_ip
   associate_public_ip_address = var.associate_public_ip || var.associate_eip
   source_dest_check           = var.source_dest_check
-  vpc_security_group_ids      = [module.security_group.id]
+  #vpc_security_group_ids      = [module.security_group.id]
 
   ###  STORAGE  ###
   root_block_device {

--- a/locals.tf
+++ b/locals.tf
@@ -10,7 +10,6 @@ locals {
 
 # For additional sg attachment
 locals {
-  additional_sg_to_primary_eni    = setproduct(var.additional_security_groups, aws_instance.this[*].primary_network_interface_id)
   additional_sg_to_additional_eni = setproduct(var.additional_security_groups, var.additional_eni_ids)
 }
 

--- a/sg.tf
+++ b/sg.tf
@@ -11,14 +11,6 @@ module "security_group" {
   network_interface_resource_associations = var.additional_eni_ids
 }
 
-# Attach additional security groups to all instance primary network interfaces
-resource "aws_network_interface_sg_attachment" "primary" {
-  count = length(local.additional_sg_to_primary_eni)
-
-  security_group_id    = local.additional_sg_to_primary_eni[count.index][0]
-  network_interface_id = local.additional_sg_to_primary_eni[count.index][1]
-}
-
 # Attach additional security groups to any additional network interfaces
 resource "aws_network_interface_sg_attachment" "additional" {
   count = length(local.additional_sg_to_additional_eni)


### PR DESCRIPTION
The presence of the aws_network_interface_sg_attachment resource conflicts with the "vpc_security_group_ids" parameter in the aws_instance resource.  When you attempt to include "additional_security_group_ids", it causes a perpetual diff that removes the additional security group attachment when reapplying this module.  Simply removing the vpc_security_group_ids parameter fixes the issue.