### PR TITLE
Ebs_optimized_precondition

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ module "ad2" {
 | [aws_network_interface_attachment.eni_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface_attachment) | resource |
 | [aws_network_interface_sg_attachment.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface_sg_attachment) | resource |
 | [aws_volume_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/volume_attachment) | resource |
+| [aws_ec2_instance_type.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ec2_instance_type) | data source |
 | [aws_iam_policy.AmazonSSMManagedInstanceCore](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 
 ## Inputs

--- a/ec2.tf
+++ b/ec2.tf
@@ -58,7 +58,7 @@ resource "aws_instance" "this" {
     precondition {
       condition     = (data.aws_ec2_instance_type.this.ebs_optimized_support == "unsupported" && var.ebs_optimized == false) || (data.aws_ec2_instance_type.this.ebs_optimized_support == "supported" && var.ebs_optimized == true) || (data.aws_ec2_instance_type.this.ebs_optimized_support == "default" && var.ebs_optimized == true)
       error_message = <<-EOT
-  The instance type (${var.ec2_instance_type}) has EBS Optimized value of (${data.aws_ec2_instance_type.this.ebs_optimized_support}), 
+  The instance type (${var.ec2_instance_type}) has an EBS Optimized value of (${data.aws_ec2_instance_type.this.ebs_optimized_support}), 
   but variable ebs_optimized is set to (${var.ebs_optimized}) (default is 'true').
   Please ensure the ebs_optimized variable matches the EBS Optimized support of the instance type.
   EOT

--- a/ec2.tf
+++ b/ec2.tf
@@ -56,7 +56,7 @@ resource "aws_instance" "this" {
   lifecycle {
     ignore_changes = [root_block_device, ebs_block_device, user_data, ami]
     precondition {
-      condition     = (data.aws_ec2_instance_type.this.ebs_optimized_support == "unsupported" && var.ebs_optimized == false) || (data.aws_ec2_instance_type.this.ebs_optimized_support == "supported" && var.ebs_optimized == true)
+      condition     = (data.aws_ec2_instance_type.this.ebs_optimized_support == "unsupported" && var.ebs_optimized == false) || (data.aws_ec2_instance_type.this.ebs_optimized_support == "supported" && var.ebs_optimized == true) || (data.aws_ec2_instance_type.this.ebs_optimized_support == "default" && var.ebs_optimized == true)
       error_message = <<-EOT
   The instance type (${var.ec2_instance_type}) has EBS Optimized value of (${data.aws_ec2_instance_type.this.ebs_optimized_support}), 
   but variable ebs_optimized is set to (${var.ebs_optimized}) (default is 'true').


### PR DESCRIPTION
Add precondition check to ensure that the provided EC2 instance type actually supports EBS Optimization and to provide a more verbose error message if it doesn't in order to indicate that "ebs_optimized" variable is an invalid value.