### PR TITLE
Add tag "DataClassificationFed" with default value "Direct Impact"

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -45,9 +45,10 @@ resource "aws_instance" "this" {
   ###  TAGS  ###
   tags = merge(
     {
-      Name       = var.instance_count == 1 ? var.name : "${var.name}${count.index + 1}",
-      CNAME      = var.instance_count == 1 ? var.name : "${var.name}${count.index + 1}",
-      PatchGroup = tostring(count.index % 2 + 1) # Default PatchGroup tag increments in range 1-2
+      Name                  = var.instance_count == 1 ? var.name : "${var.name}${count.index + 1}",
+      CNAME                 = var.instance_count == 1 ? var.name : "${var.name}${count.index + 1}",
+      PatchGroup            = tostring(count.index % 2 + 1) # Default PatchGroup tag increments in range 1-2
+      DataClassificationFed = "Direct Impact"
     },
     var.tags,
     var.global_tags


### PR DESCRIPTION
Add tag "DataClassificationFed" with default value "Direct Impact".

merge() is used to merge the tags:
https://developer.hashicorp.com/terraform/language/functions/merge

If more than one given map or object defines the same key or attribute, then **the one that is later in the argument sequence** takes precedence.

The precedence is as follows:

1. Tags defined in variable "global_tags"
2. Tags defined in variable "tags"
3. Statically defined tags in ec2.tf

If you don't define tags that override "DataClassificationFed", the default value will be used:
```
tags                                 = {
          + "App"                   = "Management"
          + "CNAME"                 = "mgtcorewbstn"
          + "DataClassificationFed" = "Direct Impact"
          + "Name"                  = "mgtcorewbstn"
          + "OSType"                = "Windows"
          + "PatchGroup"            = "1"
          + "Role"                  = "windowsbastion"
          + "Schedule"              = "DefaultOfficeHours"
          + "managed_by"            = "terraform"
        }
```

If you DO define a "tags" variable with a value to "DataClassificationFed":
```
tags                                 = {
          + "App"                   = "Management"
          + "CNAME"                 = "mgtcorewbstn"
          + "DataClassificationFed" = "Federal data"
          + "Name"                  = "mgtcorewbstn"
          + "OSType"                = "Windows"
          + "PatchGroup"            = "1"
          + "Role"                  = "windowsbastion"
          + "Schedule"              = "DefaultOfficeHours"
          + "managed_by"            = "terraform"
        }
```