### PR TITLE
Added multiple private IPs logic for instance_count > 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,8 @@ module "ad2" {
 | <a name="input_instance_metadata_tags"></a> [instance\_metadata\_tags](#input\_instance\_metadata\_tags) | Enables or disables access to instance tags from the instance metadata service. Valid values include enabled or disabled | `string` | `"enabled"` | no |
 | <a name="input_keys_to_grant"></a> [keys\_to\_grant](#input\_keys\_to\_grant) | A list of kms keys to grant permissions to for the role created. | `list(string)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the ec2 instance | `string` | n/a | yes |
-| <a name="input_private_ip"></a> [private\_ip](#input\_private\_ip) | The private ip for the instance | `string` | `null` | no |
+| <a name="input_private_ip"></a> [private\_ip](#input\_private\_ip) | Single private IP for a single instance | `string` | `null` | no |
+| <a name="input_private_ips"></a> [private\_ips](#input\_private\_ips) | List of private IPs for multiple instances | `list(string)` | `[]` | no |
 | <a name="input_root_volume_size"></a> [root\_volume\_size](#input\_root\_volume\_size) | The size of the root ebs volume on the ec2 instances created | `string` | n/a | yes |
 | <a name="input_root_volume_type"></a> [root\_volume\_type](#input\_root\_volume\_type) | The type of the root ebs volume on the ec2 instances created | `string` | `"gp3"` | no |
 | <a name="input_sg_description"></a> [sg\_description](#input\_sg\_description) | This overwrites the default generated description for the security group | `string` | `"Managed by Terraform"` | no |

--- a/ec2.tf
+++ b/ec2.tf
@@ -22,7 +22,11 @@ resource "aws_instance" "this" {
 
   ###  NETWORKING  ###
   subnet_id                   = element(var.subnet_ids, count.index)
-  private_ip                  = var.private_ip
+  private_ip = (
+    var.instance_count == 1 && var.private_ip != null ? var.private_ip :
+    var.instance_count > 1 && length(var.private_ips) > count.index ? var.private_ips[count.index] :
+    null
+  )
   associate_public_ip_address = var.associate_public_ip || var.associate_eip
   source_dest_check           = var.source_dest_check
   vpc_security_group_ids      = length(var.additional_security_groups) > 0 ? concat([module.security_group.id], var.additional_security_groups) : [module.security_group.id]

--- a/variables.tf
+++ b/variables.tf
@@ -83,9 +83,15 @@ variable "subnet_ids" {
 }
 
 variable "private_ip" {
-  description = "The private ip for the instance"
+  description = "Single private IP for a single instance"
   type        = string
   default     = null
+}
+
+variable "private_ips" {
+  description = "List of private IPs for multiple instances"
+  type        = list(string)
+  default     = []
 }
 
 variable "additional_security_groups" {


### PR DESCRIPTION
There are cases where a user may wish to spin up multiple EC2s in the same module (i.e. common purpose/HA set) and also wish to specify a static IP for these instances to maintain. The changes introduce a new variable: private_ips.

When the instance count is > 1, private_ips will allow a list(string) of Static IP addresses to be passed to the instances for use in their ENI. If the instance count is = 1, private_ip will be used to specify a single string value.