### PR TITLE
Remove validation for additional_security_groups and add validation workflow.

### DIFF
--- a/.github/workflows/org-terraform-fmt.yml
+++ b/.github/workflows/org-terraform-fmt.yml
@@ -1,0 +1,15 @@
+name: Terraform fmt
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  terraform-docs:
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-fmt.yml@main
+    with:
+      terraform_version: '1.9.5'

--- a/.github/workflows/org-terraform-validate.yml
+++ b/.github/workflows/org-terraform-validate.yml
@@ -1,0 +1,11 @@
+name: Org Terraform Validate
+on:
+    pull_request:
+        types:
+        - opened
+
+jobs:
+  create-release:
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@main
+    with:
+      terraform_version: '1.9.5'

--- a/.github/workflows/org-tree-readme.yml
+++ b/.github/workflows/org-tree-readme.yml
@@ -1,0 +1,23 @@
+name: Check README on push
+
+on: [push, pull_request]
+
+jobs:
+  readme-tree-writer:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the repository to the GitHub Actions runner
+      - uses: actions/checkout@v3
+      # creates tree structure of repo
+      - name: Write tree outputs to README
+        uses: shirakiya/readme-tree-writer@v1
+      # check diff of readme.md
+      - name: Commit if diff exists
+        run: |
+          if [ "$(git diff --ignore-space-at-eol . | wc -l)" -gt "0" ]; then
+            git config user.name github-actions
+            git config user.email github-actions@github.com
+            git add .
+            git commit -m "commit by shirakiya/readme-tree-writer"
+            git push
+          fi

--- a/variables.tf
+++ b/variables.tf
@@ -114,11 +114,6 @@ variable "additional_security_groups" {
   description = "List of additional security group IDs to attach to the EC2 instance"
   type        = list(string)
   default     = []
-
-  validation {
-    condition     = var.create_security_group == true || length(var.additional_security_groups) > 0
-    error_message = "When create_security_group is set to false, you must provide at least one security group in additional_security_groups."
-  }
 }
 
 variable "associate_public_ip" {


### PR DESCRIPTION
Noted in downstream module that uses EC2 pak that it throws this error:
```
│ Error: Invalid reference in variable validation
│ 
│   on .terraform/modules/nexpose_engine/variables.tf line 119, in variable "additional_security_groups":
│  119:     condition     = var.create_security_group == true || length(var.additional_security_groups) > 0
│ 
│ The condition for variable "additional_security_groups" can only refer to
│ the variable itself, using var.additional_security_groups.
```

The validation block in a variable can only reference itself., not a different variable.

The terraform validation workflow would have caught this, but it is missing from this pak, so I added it along with fmt and tree-readme.